### PR TITLE
Fix step numbering in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ steps, but are easy to adapt if you made adjustments.
 
 ### Steps
 
-4. Before you start, make sure you have a shell open that 
+1. Before you start, make sure you have a shell open that 
    has access to the cluster. If you're in the shell used
    for the [basic setup](docs/basic-environment-setup.md)
    you used for the basic setup you should be all set. If


### PR DESCRIPTION
TL;DR
-----

Edit the README to start step numbering at one

Details
-------

The demonstration steps are numbered arbitrarily since I edited
them and moved them around a bit while running through the steps
to document them. Markdown processors will generally not care
about the numbers, but GitHub's rendering starts at the number
that you use for the first item in the list. Since I'd moved a
step from being fourth to first, it mean my list started at 4
instead of 1. I fixed it.
