### PR TITLE
Fix broken link to basic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ layered governance model to enforce these constraints.
 
 To run the demonstration, you need one or more Kubernetes
 clusters, access to Tanzu Mission Control, and an installed
-Harbor registry. You can [setup a basic environment]
-(docs/basic-environment-setup.md) using a single cluster in
-about 30 minutes. The instructions assume you followed those
-steps, but are easy to adapt if you made adjustments.
+Harbor registry. You can [setup a basic environment](docs/basic-environment-setup.md)
+using a single cluster in about 30 minutes. The instructions
+assume you followed those steps, but are easy to adapt if
+you made adjustments.
 
 ### Steps
 


### PR DESCRIPTION
TL;DR
-----

Remove stray newline that broke the link to the setup instructions

Details
-------

Reviewing the docs with my team I noticed that the link to the
setup instructions was showing the Markdown text instead of a
link. Turns out it was a stray newline between the bracket
closing the link text and the paren opening the URI. Getting
rid of that newline fixed things up.
